### PR TITLE
Fixed modman file to prevent composer error 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "repositories": [
         {
             "type": "git",
-            "url":  "https://github.com/ericthehacker/magento-phpnativepasswords.git"
+            "url":  "https://github.com/peterjaap/magento-phpnativepasswords.git"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ericthehacker/magento-phpnativepasswords",
+    "name": "peterjaap/magento-phpnativepasswords",
     "type": "magento-module",
     "description": "Adds support to Magento to optionally use PHP's native password hashing functionality.",
     "repositories": [

--- a/modman
+++ b/modman
@@ -1,7 +1,7 @@
-app/code/community/EW/NativePasswords
-app/design/adminhtml/default/default/layout/ew/nativepasswords.xml
-app/design/adminhtml/default/default/template/ew/nativepasswords
-lib/password_compat
+app/code/community/EW/NativePasswords app/code/community/EW/NativePasswords
+app/design/adminhtml/default/default/layout/ew/nativepasswords.xml app/design/adminhtml/default/default/layout/ew/nativepasswords.xml
+app/design/adminhtml/default/default/template/ew/nativepasswords app/design/adminhtml/default/default/template/ew/nativepasswords
+lib/password_compat lib/password_compat
 
 # NOTE: "Ew" not upper case is workaround to load after Enterprise_Pci :(
-app/etc/modules/Ew_NativePasswords.xml
+app/etc/modules/Ew_NativePasswords.xml app/etc/modules/Ew_NativePasswords.xml


### PR DESCRIPTION
When installing this extension through composer, it gives the error;

'Invalid row on line 1 has 1 parts, expected 2'

Composer expects the modman file two have 2 parts on each row
